### PR TITLE
[Fix] Remove placement references

### DIFF
--- a/tap_tiktok_ads/schemas/ad_insights.json
+++ b/tap_tiktok_ads/schemas/ad_insights.json
@@ -60,12 +60,6 @@
         "string"
       ]
     },
-    "placement": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "spend": {
       "type": [
         "null",

--- a/tap_tiktok_ads/schemas/adgroups.json
+++ b/tap_tiktok_ads/schemas/adgroups.json
@@ -35,18 +35,6 @@
         "string"
       ]
     },
-    "placement": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "string"
-        ]
-      }
-    },
     "enable_inventory_filter": {
       "type": [
         "null",

--- a/tap_tiktok_ads/streams.py
+++ b/tap_tiktok_ads/streams.py
@@ -16,7 +16,6 @@ AUCTION_FIELDS = """[
     "adgroup_name",
     "campaign_id",
     "campaign_name",
-    "placement",
     "spend",
     "cpc",
     "cpm",


### PR DESCRIPTION
# Description of change
Receiving error from og tap: `Invalid metric fields: ['placement'].`
Remove references to placements in streams.py and relevant jsons (ad_insights, adgroups)

# Manual QA steps
 - run tap locally 
 
# Rollback steps
 - revert this branch
